### PR TITLE
fix Eval() for expressions returning complex types

### DIFF
--- a/raymond.go
+++ b/raymond.go
@@ -27,21 +27,17 @@ func MustRender(source string, ctx interface{}) string {
 	return MustParse(source).MustExec(ctx)
 }
 
-// Eval parses a template and evaluates it with given context.
+// EvalSingleExpression parses a template with one expression and evaluates it
+// with given context.
 //
-// This is usefule to evaluate helper calls etc.
-func Eval(source string, ctx interface{}) (interface{}, error) {
+// This is useful to evaluate helper calls etc.
+func EvalSingleExpression(source string, ctx interface{}) (interface{}, error) {
 	// parse template
-	tpl, err := Parse(source)
+	sexpr, err := ParseSingleExpression(source)
 	if err != nil {
 		return "", err
 	}
 
-	// evaluate template
-	res, err := tpl.Eval(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	return res, nil
+	// evaluate expression
+	return sexpr.Eval(ctx), nil
 }

--- a/single_expression_template.go
+++ b/single_expression_template.go
@@ -1,0 +1,68 @@
+package raymond
+
+import (
+	"errors"
+
+	"github.com/aymerick/raymond/ast"
+)
+
+type SingleExpression struct {
+	tpl  *Template
+	expr *ast.Expression
+}
+
+// Parse instanciates a SingleExpression by parsing given source.
+func ParseSingleExpression(source string) (*SingleExpression, error) {
+	tpl := newTemplate(source)
+
+	// parse template
+	if err := tpl.parse(); err != nil {
+		return nil, err
+	}
+
+	// validate single-expression-ness
+	expr, err := validateSingleExpression(tpl.program.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SingleExpression{
+		tpl:  tpl,
+		expr: expr,
+	}, nil
+}
+
+func validateSingleExpression(body []ast.Node) (*ast.Expression, error) {
+	if len(body) == 0 {
+		return nil, errors.New("the template is empty")
+	}
+
+	if len(body) != 1 {
+		return nil, errors.New("you can only evaluate one expression at a time")
+	}
+
+	if body[0].Type() != ast.NodeMustache {
+		return nil, errors.New("template does not contain a mustache statement")
+	}
+
+	stat, ok := body[0].(*ast.MustacheStatement)
+	if !ok {
+		return nil, errors.New("template does not contain a mustache statement")
+	}
+
+	return stat.Expression, nil
+}
+
+// EvalWith evaluates the single-expression template with given context and private data frame.
+func (sexpr *SingleExpression) EvalWith(ctx interface{}, privData *DataFrame) (result interface{}) {
+	// setup visitor
+	v := newEvalVisitor(sexpr.tpl, ctx, privData)
+
+	// visit AST
+	return sexpr.expr.Accept(v)
+}
+
+// Eval evaluates template with given context.
+func (sexpr *SingleExpression) Eval(ctx interface{}) (result interface{}) {
+	return sexpr.EvalWith(ctx, nil)
+}

--- a/template.go
+++ b/template.go
@@ -217,7 +217,7 @@ func (tpl *Template) ExecWith(ctx interface{}, privData *DataFrame) (result stri
 	v := newEvalVisitor(tpl, ctx, privData)
 
 	// visit AST
-	result = tpl.program.Accept(v).(string)
+	result, _ = tpl.program.Accept(v).(string)
 
 	return
 }

--- a/template.go
+++ b/template.go
@@ -205,17 +205,6 @@ func (tpl *Template) MustExec(ctx interface{}) string {
 
 // ExecWith executes the template with given context and private data frame.
 func (tpl *Template) ExecWith(ctx interface{}, privData *DataFrame) (result string, err error) {
-	evaled, err := tpl.EvalWith(ctx, privData)
-	if err != nil {
-		return "", err
-	}
-
-	result, _ = evaled.(string)
-	return
-}
-
-// EvalWith evaluates the template with given context and private data frame.
-func (tpl *Template) EvalWith(ctx interface{}, privData *DataFrame) (result interface{}, err error) {
 	defer errRecover(&err)
 
 	// parses template if necessary
@@ -228,15 +217,9 @@ func (tpl *Template) EvalWith(ctx interface{}, privData *DataFrame) (result inte
 	v := newEvalVisitor(tpl, ctx, privData)
 
 	// visit AST
-	result = tpl.program.Accept(v)
+	result = tpl.program.Accept(v).(string)
 
-	// named return values
 	return
-}
-
-// Eval evaluates template with given context.
-func (tpl *Template) Eval(ctx interface{}) (result interface{}, err error) {
-	return tpl.EvalWith(ctx, nil)
 }
 
 // errRecover recovers evaluation panic


### PR DESCRIPTION
`Eval` becomes `EvalSingleExpression` and now checks the source template to contain just one expression. It then "visits" (evaluates) that expression directly to avoid string conversion enforced by `evalVisitor` when entering from a template's `*ast.Program` field.